### PR TITLE
Show successful HTTP ratio in external API monitoring

### DIFF
--- a/src/features/external-api-monitoring/ExternalApiMonitoringPage.tsx
+++ b/src/features/external-api-monitoring/ExternalApiMonitoringPage.tsx
@@ -78,11 +78,20 @@ function formatDuration(ms?: number | null): string {
 	return `${minutes}m${seconds}s`;
 }
 
-function formatHttpRatio(failed?: number | null, total?: number | null): string {
-	const f = failed ?? 0;
+function httpSuccessCount(failed?: number | null, total?: number | null): number {
 	const tot = total ?? 0;
-	if (f === 0 && tot === 0) return '—';
-	return `${f}/${tot}`;
+	const failedCount = failed ?? 0;
+	return Math.max(0, tot - failedCount);
+}
+
+function formatHttpRatio(failed?: number | null, total?: number | null): string {
+	const tot = total ?? 0;
+	if (tot === 0) return '—';
+	return `${httpSuccessCount(failed, tot)}/${tot}`;
+}
+
+function hasHttpFailures(failed?: number | null): boolean {
+	return (failed ?? 0) > 0;
 }
 
 type CounterDetailKey =
@@ -715,11 +724,10 @@ export default function ExternalApiMonitoringPage(): JSX.Element {
 															<Typography
 																component="span"
 																sx={{
-																	color:
-																		(run.httpRequestsFailed ?? 0) > 0
-																			? '#f43f5e'
-																			: 'text.secondary',
-																	fontWeight: (run.httpRequestsFailed ?? 0) > 0 ? 700 : 500,
+																	color: hasHttpFailures(run.httpRequestsFailed)
+																		? '#f43f5e'
+																		: 'text.secondary',
+																	fontWeight: hasHttpFailures(run.httpRequestsFailed) ? 700 : 500,
 																}}
 															>
 																{formatHttpRatio(run.httpRequestsFailed, run.httpRequestsTotal)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- HTTP column now shows successful/total requests (e.g. `3/3` instead of `0/3`).
- Bold red styling remains when at least one HTTP request failed.

## Test plan

- [x] `npm run type-check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5443dc1f-1c6f-4da7-86e4-3be9ee769f74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5443dc1f-1c6f-4da7-86e4-3be9ee769f74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

