### PR TITLE
feat(flashscore): sandbox FULL_MATCH UI and team alias fields

### DIFF
--- a/i18n/de/translation.json
+++ b/i18n/de/translation.json
@@ -342,6 +342,9 @@
 	"teamRuscoreSection": "ruscore.ru",
 	"teamRuscoreExternalName": "Name auf ruscore.ru",
 	"teamRuscoreExternalNameHint": "Exakter Text von der Seite, wenn er vom Teamnamen abweicht",
+	"teamFlashscoreSection": "flashscorekz.com",
+	"teamFlashscoreExternalName": "Name auf flashscorekz.com",
+	"teamFlashscoreExternalNameHint": "Exakter Text von der Seite, wenn er vom Teamnamen abweicht",
 	"teamMarathonbetSection": "Marathonbet (new.marathonbet.ru)",
 	"teamMarathonbetExternalName": "Name in der Marathonbet-Linie",
 	"teamMarathonbetExternalNameHint": "Exakter Text von der Seite, z. B. Korea Republic oder Mexiko (ohne „(Sieg)“)",
@@ -379,6 +382,7 @@
 	"externalTeamAliasProvider24score": "24score.pro",
 	"externalTeamAliasProviderChampionat": "championat.com",
 	"externalTeamAliasProviderRuscore": "ruscore.ru",
+	"externalTeamAliasProviderFlashscore": "flashscorekz.com",
 	"manualExternalSyncTitle": "Manuelle Synchronisation",
 	"manualExternalSyncHint": "Einmalige SCHEDULE-, ODDS- (Marathonbet / Melbet) und LIVE-Sync für eine ausgewählte Liga.",
 	"externalDataScheduleSyncTitle": "Spielplan jetzt",
@@ -738,6 +742,12 @@
 		"ruscoreTournamentNotConfigured": "ruscore Season-ID / Slug für diese Liga nicht konfiguriert",
 		"ruscoreTeamNamesEmpty": "Auf ruscore keine Teamnamen gefunden",
 		"ruscoreFullMatchParseFailed": "ruscore-Spielkarte konnte nicht geparst werden",
+		"flashscoreFetchFailed": "flashscorekz.com-Feed konnte nicht geladen werden",
+		"flashscoreParseFailed": "Antwort von flashscorekz.com konnte nicht geparst werden",
+		"flashscoreGameIdRequired": "flashscore Event-ID angeben",
+		"flashscoreTournamentNotConfigured": "flashscore-Turnierpfad für diese Liga nicht konfiguriert",
+		"flashscoreTeamNamesEmpty": "Auf flashscore keine Teamnamen gefunden",
+		"flashscoreFullMatchParseFailed": "flashscore-Spielkarte konnte nicht geparst werden",
 		"soccer365CompetitionNotConfigured": "soccer365 competitionId ist für diese Liga nicht konfiguriert",
 		"soccer365MatchdayOneTeamNamesEmpty": "soccer365-Spielplan hat keine Spiele des 1. Spieltags — Teamnamen nicht verfügbar",
 		"sportsRuFetchFailed": "Seite von sports.ru konnte nicht geladen werden",
@@ -1219,6 +1229,9 @@
 			"ruscoreFetchFailed": "ruscore: Netz/HTTP",
 			"ruscoreParseFailed": "ruscore: HTML-Parse",
 			"ruscoreFullMatchParseFailed": "ruscore: Spielkarte",
+			"flashscoreFetchFailed": "flashscore: Netz/HTTP",
+			"flashscoreParseFailed": "flashscore: Feed-Parse",
+			"flashscoreFullMatchParseFailed": "flashscore: Spielkarte",
 			"soccer365GameIdRequired": "soccer365 game id fehlt",
 			"soccer365FullMatchParseFailed": "soccer365: Karte nicht lesbar",
 			"sportsRuFetchFailed": "sports.ru: Netz/HTTP",
@@ -1378,7 +1391,8 @@
 				"saves": "Paraden"
 			},
 			"addedTime": "Nachspielzeit",
-			"ruscoreGameIdHint": "Format: slug/eventId (oder Spiel in der Tagesliste anklicken)"
+			"ruscoreGameIdHint": "Format: slug/eventId (oder Spiel in der Tagesliste anklicken)",
+			"flashscoreGameIdHint": "Format: eventId (8 Zeichen, oder Spiel in der Tagesliste anklicken)"
 		}
 	},
 	"externalApiMonitoring": {

--- a/i18n/en/translation.json
+++ b/i18n/en/translation.json
@@ -342,6 +342,9 @@
 	"teamRuscoreSection": "ruscore.ru",
 	"teamRuscoreExternalName": "Name on ruscore.ru",
 	"teamRuscoreExternalNameHint": "Exact label from the site when it differs from the team title",
+	"teamFlashscoreSection": "flashscorekz.com",
+	"teamFlashscoreExternalName": "Name on flashscorekz.com",
+	"teamFlashscoreExternalNameHint": "Exact label from the site when it differs from the team title",
 	"teamMarathonbetSection": "Marathonbet (new.marathonbet.ru)",
 	"teamMarathonbetExternalName": "Name on Marathonbet line",
 	"teamMarathonbetExternalNameHint": "Exact label from site, e.g. Korea Republic or Mexico (no “(win)” suffix)",
@@ -379,6 +382,7 @@
 	"externalTeamAliasProvider24score": "24score.pro",
 	"externalTeamAliasProviderChampionat": "championat.com",
 	"externalTeamAliasProviderRuscore": "ruscore.ru",
+	"externalTeamAliasProviderFlashscore": "flashscorekz.com",
 	"manualExternalSyncTitle": "Manual sync",
 	"manualExternalSyncHint": "One-off SCHEDULE, ODDS (Marathonbet / Melbet), and LIVE sync for a selected league.",
 	"externalDataScheduleSyncTitle": "Schedule now",
@@ -738,6 +742,12 @@
 		"ruscoreTournamentNotConfigured": "ruscore season id / slug is not configured for this league",
 		"ruscoreTeamNamesEmpty": "No team names found on ruscore",
 		"ruscoreFullMatchParseFailed": "Failed to parse ruscore match card",
+		"flashscoreFetchFailed": "Failed to load flashscorekz.com feed",
+		"flashscoreParseFailed": "Failed to parse flashscorekz.com response",
+		"flashscoreGameIdRequired": "Provide flashscore match event id",
+		"flashscoreTournamentNotConfigured": "flashscore tournament path is not configured for this league",
+		"flashscoreTeamNamesEmpty": "No team names found on flashscore",
+		"flashscoreFullMatchParseFailed": "Failed to parse flashscore match card",
 		"soccer365CompetitionNotConfigured": "soccer365 competitionId is not configured for this league",
 		"soccer365MatchdayOneTeamNamesEmpty": "soccer365 schedule has no matchday 1 fixtures — team names unavailable",
 		"sportsRuFetchFailed": "Failed to load sports.ru page",
@@ -1219,6 +1229,9 @@
 			"ruscoreFetchFailed": "ruscore: network/HTTP",
 			"ruscoreParseFailed": "ruscore: HTML parse",
 			"ruscoreFullMatchParseFailed": "ruscore: match card",
+			"flashscoreFetchFailed": "flashscore: network/HTTP",
+			"flashscoreParseFailed": "flashscore: feed parse",
+			"flashscoreFullMatchParseFailed": "flashscore: match card",
 			"soccer365GameIdRequired": "Missing soccer365 game id",
 			"soccer365FullMatchParseFailed": "soccer365: card parse failed",
 			"sportsRuFetchFailed": "sports.ru: network/HTTP",
@@ -1378,7 +1391,8 @@
 				"saves": "Saves"
 			},
 			"addedTime": "Added time",
-			"ruscoreGameIdHint": "Format: slug/eventId (or click a match in the day table)"
+			"ruscoreGameIdHint": "Format: slug/eventId (or click a match in the day table)",
+			"flashscoreGameIdHint": "Format: eventId (8 chars, or click a match in the day table)"
 		}
 	},
 	"externalApiMonitoring": {

--- a/i18n/ru/translation.json
+++ b/i18n/ru/translation.json
@@ -342,6 +342,9 @@
 	"teamRuscoreSection": "ruscore.ru",
 	"teamRuscoreExternalName": "Название на ruscore.ru",
 	"teamRuscoreExternalNameHint": "Точная строка с сайта, если отличается от названия команды",
+	"teamFlashscoreSection": "flashscorekz.com",
+	"teamFlashscoreExternalName": "Название на flashscorekz.com",
+	"teamFlashscoreExternalNameHint": "Точная строка с сайта, если отличается от названия команды",
 	"teamMarathonbetSection": "Marathonbet (new.marathonbet.ru)",
 	"teamMarathonbetExternalName": "Название в линии Marathonbet",
 	"teamMarathonbetExternalNameHint": "Точная строка с сайта, напр. Республика Корея или Мексика (без «(победа)»)",
@@ -379,6 +382,7 @@
 	"externalTeamAliasProvider24score": "24score.pro",
 	"externalTeamAliasProviderChampionat": "championat.com",
 	"externalTeamAliasProviderRuscore": "ruscore.ru",
+	"externalTeamAliasProviderFlashscore": "flashscorekz.com",
 	"manualExternalSyncTitle": "Ручная синхронизация",
 	"manualExternalSyncHint": "Разовые sync расписания (SCHEDULE), кэфов ODDS (Marathonbet / Melbet) и live-счётов по выбранной лиге.",
 	"externalDataScheduleSyncTitle": "Расписание сейчас",
@@ -738,6 +742,12 @@
 		"ruscoreTournamentNotConfigured": "Для лиги не задан season id / slug ruscore",
 		"ruscoreTeamNamesEmpty": "На ruscore не найдены названия команд",
 		"ruscoreFullMatchParseFailed": "Не удалось разобрать карточку матча ruscore",
+		"flashscoreFetchFailed": "Не удалось загрузить feed flashscorekz.com",
+		"flashscoreParseFailed": "Не удалось разобрать ответ flashscorekz.com",
+		"flashscoreGameIdRequired": "Укажите event id матча flashscore",
+		"flashscoreTournamentNotConfigured": "Для лиги не задан путь турнира flashscore",
+		"flashscoreTeamNamesEmpty": "На flashscore не найдены названия команд",
+		"flashscoreFullMatchParseFailed": "Не удалось разобрать карточку матча flashscore",
 		"soccer365CompetitionNotConfigured": "Для лиги не настроен competitionId soccer365",
 		"soccer365MatchdayOneTeamNamesEmpty": "В расписании soccer365 нет матчей 1-го тура — названия команд недоступны",
 		"sportsRuFetchFailed": "Не удалось загрузить страницу sports.ru",
@@ -1219,6 +1229,9 @@
 			"ruscoreFetchFailed": "ruscore: сеть/HTTP",
 			"ruscoreParseFailed": "ruscore: разбор HTML",
 			"ruscoreFullMatchParseFailed": "ruscore: карточка матча",
+			"flashscoreFetchFailed": "flashscore: сеть/HTTP",
+			"flashscoreParseFailed": "flashscore: разбор feed",
+			"flashscoreFullMatchParseFailed": "flashscore: карточка матча",
 			"soccer365GameIdRequired": "Нет soccer365 game id",
 			"soccer365FullMatchParseFailed": "soccer365: разбор карточки",
 			"sportsRuFetchFailed": "sports.ru: сеть/HTTP",
@@ -1378,7 +1391,8 @@
 				"saves": "Сэйвы"
 			},
 			"addedTime": "Добавленное время",
-			"ruscoreGameIdHint": "Формат: slug/eventId (или клик по матчу в таблице дня)"
+			"ruscoreGameIdHint": "Формат: slug/eventId (или клик по матчу в таблице дня)",
+			"flashscoreGameIdHint": "Формат: eventId (8 символов, или клик по матчу в таблице дня)"
 		}
 	},
 	"externalApiMonitoring": {

--- a/src/features/admin/external-data/ExternalTeamAliasesPanel.tsx
+++ b/src/features/admin/external-data/ExternalTeamAliasesPanel.tsx
@@ -32,6 +32,7 @@ import {
 	TWENTYFOUR_SCORE_PROVIDER,
 	CHAMPIONAT_PROVIDER,
 	RUSCORE_PROVIDER,
+	FLASHSCORE_PROVIDER,
 } from '../teams/teamProviderConstants';
 import {
 	ExternalTeamNameChip,
@@ -48,6 +49,7 @@ const PROVIDERS = [
 	TWENTYFOUR_SCORE_PROVIDER,
 	CHAMPIONAT_PROVIDER,
 	RUSCORE_PROVIDER,
+	FLASHSCORE_PROVIDER,
 ] as const;
 
 const PROVIDER_LEAGUE_CODES: Record<string, Set<string>> = {
@@ -59,6 +61,7 @@ const PROVIDER_LEAGUE_CODES: Record<string, Set<string>> = {
 	[TWENTYFOUR_SCORE_PROVIDER]: new Set(['EPL', 'BL']),
 	[CHAMPIONAT_PROVIDER]: new Set(['EPL', 'BL']),
 	[RUSCORE_PROVIDER]: new Set(['EPL', 'BL', 'CL', 'LE']),
+	[FLASHSCORE_PROVIDER]: new Set(['EPL', 'BL']),
 };
 
 const PROVIDER_LABEL_KEY: Record<string, string> = {
@@ -70,6 +73,7 @@ const PROVIDER_LABEL_KEY: Record<string, string> = {
 	[TWENTYFOUR_SCORE_PROVIDER]: 'externalTeamAliasProvider24score',
 	[CHAMPIONAT_PROVIDER]: 'externalTeamAliasProviderChampionat',
 	[RUSCORE_PROVIDER]: 'externalTeamAliasProviderRuscore',
+	[FLASHSCORE_PROVIDER]: 'externalTeamAliasProviderFlashscore',
 };
 
 export default function ExternalTeamAliasesPanel(): JSX.Element {

--- a/src/features/admin/teams/teamFormUtils.ts
+++ b/src/features/admin/teams/teamFormUtils.ts
@@ -10,6 +10,7 @@ import {
 	TWENTYFOUR_SCORE_PROVIDER,
 	CHAMPIONAT_PROVIDER,
 	RUSCORE_PROVIDER,
+	FLASHSCORE_PROVIDER,
 } from './teamProviderConstants';
 
 const DROPPED_PROVIDERS = new Set([
@@ -73,6 +74,13 @@ export const TEAM_EXTERNAL_ALIAS_FIELDS = [
 		sectionKey: 'teamRuscoreSection',
 		labelKey: 'teamRuscoreExternalName',
 		inputId: 'ruscore-external-name',
+	},
+	{
+		provider: FLASHSCORE_PROVIDER,
+		field: 'flashscoreExternalName',
+		sectionKey: 'teamFlashscoreSection',
+		labelKey: 'teamFlashscoreExternalName',
+		inputId: 'flashscore-external-name',
 	},
 	{
 		provider: MARATHONBET_PROVIDER,

--- a/src/features/admin/teams/teamProviderConstants.ts
+++ b/src/features/admin/teams/teamProviderConstants.ts
@@ -7,3 +7,4 @@ export const SOCCER365_PROVIDER = 'soccer365.ru';
 export const SPORTS_RU_PROVIDER = 'sports.ru';
 export const FOOTBALL24_PROVIDER = 'football24.ua';
 export const RUSCORE_PROVIDER = 'ruscore.ru';
+export const FLASHSCORE_PROVIDER = 'flashscorekz.com';

--- a/src/features/api-sandbox/ApiSandboxPage.tsx
+++ b/src/features/api-sandbox/ApiSandboxPage.tsx
@@ -236,7 +236,7 @@ export default function ApiSandboxPage(): JSX.Element {
 		const provider = fullMatch.form.provider;
 		const gameId = fullMatch.form.gameId.trim();
 		const date = fullMatch.form.date.trim();
-		if (provider === 'ruscore.ru') {
+		if (provider === 'ruscore.ru' || provider === 'flashscorekz.com') {
 			if (!gameId && !date) {
 				dispatch(showErrorSnackbar({ message: 'sandboxDateRequired' }));
 				return;

--- a/src/features/api-sandbox/sandboxProviderHints.ts
+++ b/src/features/api-sandbox/sandboxProviderHints.ts
@@ -7,6 +7,7 @@ import {
 	TWENTYFOUR_SCORE_PROVIDER,
 	CHAMPIONAT_PROVIDER,
 	RUSCORE_PROVIDER,
+	FLASHSCORE_PROVIDER,
 } from '../admin/teams/teamProviderConstants';
 import type { ExternalDataLayer } from '../../shared/externalDataLayerColors';
 
@@ -91,6 +92,12 @@ export const SANDBOX_ID_HINTS: Partial<
 			{ label: 'LE', value: '5360' },
 			{ label: '2.BL', value: 'Вторая Бундеслига' },
 			{ label: 'EPL name', value: 'england-premier-league' },
+		],
+		[FLASHSCORE_PROVIDER]: [
+			{ label: 'EPL', value: 'Premier League' },
+			{ label: 'BL', value: 'Bundesliga' },
+			{ label: 'EPL stage', value: 'CfoA8Dmm' },
+			{ label: 'BL stage', value: 'jg0MwVuC' },
 		],
 	},
 };

--- a/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
+++ b/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
@@ -120,7 +120,9 @@ type DayBrowseParsed = {
 	competitions?: Array<{
 		title?: string;
 		seasonId?: number | null;
+		stageId?: string | null;
 		tournamentSlug?: string | null;
+		tournamentPath?: string | null;
 		matches?: DayMatchRow[];
 	}>;
 };
@@ -203,6 +205,8 @@ export default function FullMatchSandboxStand({
 	const providerOptions = providers.length > 0 ? providers : ['soccer365.ru'];
 	const safeProvider = providerOptions.includes(form.provider) ? form.provider : providerOptions[0];
 	const isRuscore = safeProvider === 'ruscore.ru';
+	const isFlashscore = safeProvider === 'flashscorekz.com';
+	const isDayBrowseProvider = isRuscore || isFlashscore;
 	const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
 
 	const parsed = result?.parsed ?? null;
@@ -221,7 +225,11 @@ export default function FullMatchSandboxStand({
 					<Box key={`${comp.seasonId || comp.title}-${cIdx}`}>
 						<Typography sx={{ fontWeight: 700, fontSize: '0.85rem', mb: 0.5 }}>
 							{comp.title || '—'}
-							{comp.seasonId != null ? ` · ${comp.seasonId}` : ''}
+							{comp.seasonId != null
+								? ` · ${comp.seasonId}`
+								: comp.stageId
+									? ` · ${comp.stageId}`
+									: ''}
 						</Typography>
 						<TableContainer>
 							<Table size="small" sx={sandboxTableSx(layer)}>
@@ -498,7 +506,9 @@ export default function FullMatchSandboxStand({
 					{t('apiSandbox.layer.FULL_MATCH')}
 				</Typography>
 				<Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', mt: -1 }}>
-					{isRuscore ? t('apiSandbox.fullMatchHintRuscore') : t('apiSandbox.fullMatchHint')}
+					{isDayBrowseProvider
+						? t('apiSandbox.fullMatchHintRuscore')
+						: t('apiSandbox.fullMatchHint')}
 				</Typography>
 
 				<Box>
@@ -523,7 +533,7 @@ export default function FullMatchSandboxStand({
 					</FormControl>
 				</Box>
 
-				{isRuscore ? (
+				{isDayBrowseProvider ? (
 					<>
 						<Box>
 							<Typography sx={sandboxFieldLabelSx}>{t('apiSandbox.fields.date')}</Typography>
@@ -553,8 +563,12 @@ export default function FullMatchSandboxStand({
 								size="small"
 								value={form.gameId}
 								onChange={(e) => onFormChange({ ...form, gameId: e.target.value })}
-								placeholder="slug/563678"
-								helperText={t('apiSandbox.fullMatch.ruscoreGameIdHint')}
+								placeholder={isFlashscore ? 'nNUWaFf5' : 'slug/563678'}
+								helperText={
+									isFlashscore
+										? t('apiSandbox.fullMatch.flashscoreGameIdHint')
+										: t('apiSandbox.fullMatch.ruscoreGameIdHint')
+								}
 							/>
 						</Box>
 					</>
@@ -575,7 +589,7 @@ export default function FullMatchSandboxStand({
 					layer={layer}
 					provider={safeProvider}
 					onApply={
-						isRuscore
+						isDayBrowseProvider
 							? (value) => onFormChange({ ...form, titleContains: value })
 							: undefined
 					}
@@ -596,7 +610,11 @@ export default function FullMatchSandboxStand({
 					result={result}
 					accent={accent}
 					summary={daySummary || cardSummary}
-					emptyHint={isRuscore ? t('apiSandbox.fullMatchEmptyRuscore') : t('apiSandbox.fullMatchEmpty')}
+					emptyHint={
+						isDayBrowseProvider
+							? t('apiSandbox.fullMatchEmptyRuscore')
+							: t('apiSandbox.fullMatchEmpty')
+					}
 				/>
 			</Box>
 		</Box>


### PR DESCRIPTION
Add flashscorekz.com to API sandbox (date/league browse + eventId load), team admin alias field, external aliases panel for EPL/BL, and i18n strings.