### PR TITLE
fix(sandbox): render match stats inside finished card preview

### DIFF
--- a/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
+++ b/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
@@ -19,7 +19,6 @@ import CustomSuccessButton from '../../../components/custom/btn/CustomSuccessBut
 import { useFormatUserDateTime } from '../../../shared/useFormatUserDateTime';
 import { getGameScoreView } from '../../../components/utils/gameScoreValidation';
 import ExternalMatchFinishedPreview from '../../match-results/ExternalMatchFinishedPreview';
-import MatchStatsSection from '../../match-results/MatchStatsSection';
 import type MatchTeamStats from '../../match-results/types/MatchTeamStats';
 import type { SandboxResult } from '../apiSandboxApi';
 import {
@@ -264,8 +263,8 @@ export default function FullMatchSandboxStand({
 						events={cardParsed.goals}
 						addedTimeFirstHalf={cardParsed.addedTimeFirstHalf}
 						addedTimeSecondHalf={cardParsed.addedTimeSecondHalf}
+						stats={cardParsed.stats}
 					/>
-					<MatchStatsSection stats={cardParsed.stats} />
 				</Box>
 
 				<Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/src/features/match-results/ExternalMatchFinishedPreview.tsx
+++ b/src/features/match-results/ExternalMatchFinishedPreview.tsx
@@ -18,7 +18,9 @@ import {
 	externalMatchBetsDialogTeamsRowSx,
 } from './externalMatchBetsDialogStyles';
 import MatchEventsTimeline from './MatchEventsTimeline';
+import MatchStatsSection from './MatchStatsSection';
 import type MatchGoalEvent from './types/MatchGoalEvent';
+import type MatchTeamStats from './types/MatchTeamStats';
 
 type Props = {
 	homeTeam: Team;
@@ -27,6 +29,8 @@ type Props = {
 	events?: MatchGoalEvent[] | null;
 	addedTimeFirstHalf?: number | null;
 	addedTimeSecondHalf?: number | null;
+	/** FULL_MATCH stats (sandbox: from fetch; production: from match_schedules). */
+	stats?: MatchTeamStats | null;
 	/** Optional caption under score (e.g. bets count preview). */
 	footerHint?: string;
 };
@@ -42,6 +46,7 @@ export default function ExternalMatchFinishedPreview({
 	events,
 	addedTimeFirstHalf,
 	addedTimeSecondHalf,
+	stats,
 	footerHint,
 }: Props): JSX.Element {
 	const { t, i18n } = useTranslation();
@@ -117,14 +122,19 @@ export default function ExternalMatchFinishedPreview({
 				) : null}
 			</Box>
 
-			<Box sx={{ px: 1.25, pt: 0.85, pb: 0.5 }}>
-				<MatchEventsTimeline
-					events={events}
-					addedTimeFirstHalf={addedTimeFirstHalf}
-					addedTimeSecondHalf={addedTimeSecondHalf}
-					hideWhenEmpty
-				/>
-			</Box>
+			{(events && events.length > 0)
+				|| addedTimeFirstHalf != null
+				|| addedTimeSecondHalf != null ? (
+				<Box sx={{ px: 1.25, pt: 0.85, pb: 0.35, flexShrink: 0 }}>
+					<MatchEventsTimeline
+						events={events}
+						addedTimeFirstHalf={addedTimeFirstHalf}
+						addedTimeSecondHalf={addedTimeSecondHalf}
+					/>
+				</Box>
+			) : null}
+
+			<MatchStatsSection stats={stats} />
 
 			<Box sx={{ px: 1.25, pb: 1.25 }}>
 				<Typography sx={externalMatchBetsDialogEmptySx}>


### PR DESCRIPTION
Move MatchStatsSection into ExternalMatchFinishedPreview between events and the bets placeholder so sandbox mirrors the production dialog layout.