### PR TITLE
fix(sandbox): pass resolved team displayNames into match card preview

### DIFF
--- a/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
+++ b/src/features/api-sandbox/stands/FullMatchSandboxStand.tsx
@@ -58,6 +58,11 @@ type FullMatchParsedTeam = {
 	id?: string;
 	title?: string;
 	logoKey?: string | null;
+	displayNames?: {
+		en?: string;
+		ru?: string;
+		de?: string;
+	};
 };
 
 type FullMatchCardParsed = {
@@ -135,6 +140,7 @@ function teamFromParsed(resolved: FullMatchParsedTeam | null | undefined, fallba
 		id: resolved?.id || `sandbox-${title}`,
 		title,
 		logoKey,
+		displayNames: resolved?.displayNames,
 	};
 }
 

--- a/src/features/api-sandbox/stands/LiveSandboxStand.tsx
+++ b/src/features/api-sandbox/stands/LiveSandboxStand.tsx
@@ -48,6 +48,11 @@ type LiveParsedTeam = {
 	id?: string;
 	title?: string;
 	logoKey?: string | null;
+	displayNames?: {
+		en?: string;
+		ru?: string;
+		de?: string;
+	};
 };
 
 type LiveParsedMatch = {
@@ -102,6 +107,7 @@ function teamFromParsed(resolved: LiveParsedTeam | null | undefined, fallbackNam
 		id: resolved?.id || `sandbox-${title}`,
 		title,
 		logoKey,
+		displayNames: resolved?.displayNames,
 	};
 }
 


### PR DESCRIPTION
Include displayNames from sandbox alias resolve so finished-card previews show logos and localized names when aliases match.