### PR TITLE
Починить автообновление вкладок при новом деплое

### DIFF
--- a/src/shared/appVersionCheckLogic.test.ts
+++ b/src/shared/appVersionCheckLogic.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	clearReloadAttempt,
+	parseBuildId,
+	pickNewestBuildId,
+	reloadForBuildId,
+	resolveVersionCheckOutcome,
+	shouldRegisterLocal,
+	shouldReload,
+} from './appVersionCheckLogic';
+
+describe('appVersionCheckLogic', () => {
+	afterEach(() => {
+		sessionStorage.clear();
+		vi.restoreAllMocks();
+	});
+
+	it('parseBuildId supports decimal and legacy base36 ids', () => {
+		expect(parseBuildId('1750000000000')).toBe(1750000000000);
+		expect(parseBuildId('lkz8f0')).toBe(parseInt('lkz8f0', 36));
+		expect(parseBuildId('not-a-version')).toBeNull();
+	});
+
+	it('pickNewestBuildId chooses the highest numeric build id', () => {
+		expect(pickNewestBuildId('100', '250', '200')).toBe('250');
+		expect(pickNewestBuildId(null, undefined, '120')).toBe('120');
+	});
+
+	it('shouldReload only when remote is newer', () => {
+		expect(shouldReload('100', '200')).toBe(true);
+		expect(shouldReload('200', '100')).toBe(false);
+		expect(shouldReload('200', '200')).toBe(false);
+	});
+
+	it('shouldRegisterLocal when local is newer or remote missing', () => {
+		expect(shouldRegisterLocal('300', '200')).toBe(true);
+		expect(shouldRegisterLocal('100', '200')).toBe(false);
+		expect(shouldRegisterLocal('100', null)).toBe(true);
+	});
+
+	it('resolveVersionCheckOutcome reloads old tab when static version is newer', () => {
+		const outcome = resolveVersionCheckOutcome('100', '300', '200', null);
+		expect(outcome).toEqual({ type: 'reload', remoteBuildId: '300' });
+	});
+
+	it('resolveVersionCheckOutcome registers when no remote version exists', () => {
+		const outcome = resolveVersionCheckOutcome('100', null, null, null);
+		expect(outcome).toEqual({ type: 'register', buildId: '100' });
+	});
+
+	it('reloadForBuildId retries with cache-busting query on second attempt', () => {
+		const replace = vi.fn();
+		const reload = vi.fn();
+		vi.stubGlobal('location', {
+			href: 'https://example.com/app/',
+			reload,
+			replace,
+		});
+
+		reloadForBuildId('300', '100');
+		expect(sessionStorage.getItem('appReloadAttempt:100')).toBe('300');
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		reloadForBuildId('300', '100');
+		expect(replace).toHaveBeenCalledWith('https://example.com/app/?_v=300');
+	});
+
+	it('clearReloadAttempt removes reload marker for local build', () => {
+		sessionStorage.setItem('appReloadAttempt:100', '300');
+		clearReloadAttempt('100');
+		expect(sessionStorage.getItem('appReloadAttempt:100')).toBeNull();
+	});
+});

--- a/src/shared/appVersionCheckLogic.ts
+++ b/src/shared/appVersionCheckLogic.ts
@@ -1,0 +1,175 @@
+export const VERSION_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+const RELOAD_ATTEMPT_PREFIX = 'appReloadAttempt:';
+
+export type VersionPayload = {
+	buildId: string | null;
+};
+
+export function parseBuildId(value: string): number | null {
+	if (/^\d+$/.test(value)) {
+		const numeric = Number(value);
+		return Number.isFinite(numeric) ? numeric : null;
+	}
+	if (/^[0-9a-z]+$/i.test(value)) {
+		const legacy = parseInt(value, 36);
+		return Number.isFinite(legacy) && legacy > 0 ? legacy : null;
+	}
+	return null;
+}
+
+export function pickNewestBuildId(...ids: Array<string | null | undefined>): string | null {
+	let bestId: string | null = null;
+	let bestNum = -1;
+	for (const id of ids) {
+		if (!id) {
+			continue;
+		}
+		const num = parseBuildId(id);
+		if (num == null) {
+			continue;
+		}
+		if (num > bestNum) {
+			bestNum = num;
+			bestId = id;
+		}
+	}
+	return bestId;
+}
+
+export function shouldReload(localId: string, remoteId: string): boolean {
+	if (!remoteId || localId === remoteId) {
+		return false;
+	}
+	const localNum = parseBuildId(localId);
+	const remoteNum = parseBuildId(remoteId);
+	if (localNum == null || remoteNum == null) {
+		return localId !== remoteId;
+	}
+	return localNum < remoteNum;
+}
+
+export function shouldRegisterLocal(localId: string, remoteId: string | null): boolean {
+	if (!remoteId) {
+		return true;
+	}
+	const localNum = parseBuildId(localId);
+	const remoteNum = parseBuildId(remoteId);
+	if (localNum == null || remoteNum == null) {
+		return localId !== remoteId;
+	}
+	return localNum > remoteNum;
+}
+
+function reloadAttemptKey(localBuildId: string): string {
+	return `${RELOAD_ATTEMPT_PREFIX}${localBuildId}`;
+}
+
+export function clearReloadAttempt(localBuildId: string): void {
+	try {
+		sessionStorage.removeItem(reloadAttemptKey(localBuildId));
+	} catch {
+		// ignore
+	}
+}
+
+export function reloadForBuildId(remoteBuildId: string, localBuildId: string): void {
+	try {
+		const key = reloadAttemptKey(localBuildId);
+		if (sessionStorage.getItem(key) === remoteBuildId) {
+			const url = new URL(window.location.href);
+			url.searchParams.set('_v', remoteBuildId);
+			window.location.replace(url.toString());
+			return;
+		}
+		sessionStorage.setItem(key, remoteBuildId);
+	} catch {
+		// sessionStorage может быть недоступен — всё равно пробуем reload
+	}
+	window.location.reload();
+}
+
+export function staticVersionUrl(): string {
+	const base = import.meta.env.BASE_URL ?? '/';
+	const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+	return `${normalizedBase}version.json`;
+}
+
+export function clientVersionUrl(path: string): string {
+	if (import.meta.env.VITE_PRODUCT_SERVER === 'localhost') {
+		return path;
+	}
+	return `${import.meta.env.VITE_PRODUCT_SERVER}${path}`;
+}
+
+export async function fetchJsonBuildId(
+	url: string,
+	fetchFn: typeof fetch = fetch
+): Promise<string | null> {
+	try {
+		const response = await fetchFn(url, { cache: 'no-store' });
+		if (!response.ok) {
+			return null;
+		}
+		const data = (await response.json()) as VersionPayload;
+		return typeof data.buildId === 'string' && data.buildId ? data.buildId : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function fetchStaticBuildId(fetchFn: typeof fetch = fetch): Promise<string | null> {
+	const url = `${staticVersionUrl()}?t=${Date.now()}`;
+	return fetchJsonBuildId(url, fetchFn);
+}
+
+export async function fetchApiBuildId(fetchFn: typeof fetch = fetch): Promise<string | null> {
+	return fetchJsonBuildId(clientVersionUrl('/api/client-version'), fetchFn);
+}
+
+export async function registerBuildId(
+	buildId: string,
+	fetchFn: typeof fetch = fetch
+): Promise<string | null> {
+	try {
+		const response = await fetchFn(clientVersionUrl('/api/client-version/register'), {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			cache: 'no-store',
+			body: JSON.stringify({ buildId }),
+		});
+		if (!response.ok) {
+			return null;
+		}
+		const data = (await response.json()) as VersionPayload;
+		return typeof data.buildId === 'string' && data.buildId ? data.buildId : null;
+	} catch {
+		return null;
+	}
+}
+
+export type VersionCheckOutcome =
+	| { type: 'noop' }
+	| { type: 'register'; buildId: string }
+	| { type: 'reload'; remoteBuildId: string };
+
+export function resolveVersionCheckOutcome(
+	localId: string,
+	staticId: string | null,
+	apiId: string | null,
+	registeredId: string | null
+): VersionCheckOutcome {
+	const remoteId = pickNewestBuildId(staticId, apiId, registeredId);
+	if (!remoteId) {
+		return { type: 'register', buildId: localId };
+	}
+	if (remoteId === localId) {
+		return { type: 'noop' };
+	}
+	if (shouldRegisterLocal(localId, remoteId)) {
+		return { type: 'register', buildId: localId };
+	}
+	if (shouldReload(localId, remoteId)) {
+		return { type: 'reload', remoteBuildId: remoteId };
+	}
+	return { type: 'noop' };
+}

--- a/src/shared/useAppVersionCheck.ts
+++ b/src/shared/useAppVersionCheck.ts
@@ -1,76 +1,21 @@
 import { useEffect, useRef } from 'react';
 import { apiFetch } from './apiClient';
+import {
+	VERSION_CHECK_INTERVAL_MS,
+	clearReloadAttempt,
+	fetchApiBuildId,
+	fetchStaticBuildId,
+	registerBuildId,
+	reloadForBuildId,
+	resolveVersionCheckOutcome,
+} from './appVersionCheckLogic';
 
-const CHECK_INTERVAL_MS = 5 * 60 * 1000;
-const RELOAD_STORAGE_KEY = 'appReloadForBuildId';
-
-type VersionPayload = {
-	buildId: string | null;
-};
-
-function clientVersionUrl(path: string): string {
-	if (import.meta.env.VITE_PRODUCT_SERVER === 'localhost') {
-		return path;
-	}
-	return `${import.meta.env.VITE_PRODUCT_SERVER}${path}`;
-}
-
-async function fetchRemoteBuildId(): Promise<string | null> {
-	try {
-		const response = await apiFetch(clientVersionUrl('/api/client-version'), {
-			cache: 'no-store',
-		});
-		if (!response.ok) {
-			return null;
-		}
-		const data = (await response.json()) as VersionPayload;
-		return typeof data.buildId === 'string' && data.buildId ? data.buildId : null;
-	} catch {
-		return null;
-	}
-}
-
-async function registerBuildId(buildId: string): Promise<string | null> {
-	try {
-		const response = await apiFetch(clientVersionUrl('/api/client-version/register'), {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			cache: 'no-store',
-			body: JSON.stringify({ buildId }),
-		});
-		if (!response.ok) {
-			return null;
-		}
-		const data = (await response.json()) as VersionPayload;
-		return typeof data.buildId === 'string' && data.buildId ? data.buildId : null;
-	} catch {
-		return null;
-	}
-}
-
-function reloadForBuildId(remoteBuildId: string): void {
-	try {
-		if (sessionStorage.getItem(RELOAD_STORAGE_KEY) === remoteBuildId) {
-			return;
-		}
-		sessionStorage.setItem(RELOAD_STORAGE_KEY, remoteBuildId);
-	} catch {
-		// sessionStorage может быть недоступен — всё равно пробуем один reload
-	}
-	window.location.reload();
-}
-
-function parseBuildId(value: string): number | null {
-	if (!/^\d+$/.test(value)) {
-		return null;
-	}
-	const n = Number(value);
-	return Number.isFinite(n) ? n : null;
-}
+const apiFetchAdapter: typeof fetch = (input, init) => apiFetch(input, init);
 
 /**
- * В production сверяет вшитый buildId с /api/client-version (бэкенд, без CDN static).
- * Более новый клиент регистрирует версию; более старый — один принудительный reload.
+ * В production сверяет вшитый buildId с version.json (статика, сразу после деплоя)
+ * и /api/client-version (бэкенд). Более новый клиент регистрирует версию;
+ * более старый — принудительный reload.
  */
 export function useAppVersionCheck(): void {
 	const checkingRef = useRef(false);
@@ -85,47 +30,38 @@ export function useAppVersionCheck(): void {
 			return;
 		}
 
-		const localNum = parseBuildId(localId);
-		if (localNum == null) {
-			return;
-		}
-
 		const check = async (): Promise<void> => {
 			if (checkingRef.current) {
 				return;
 			}
 			checkingRef.current = true;
 			try {
-				const remoteId = await fetchRemoteBuildId();
-				if (!remoteId) {
-					await registerBuildId(localId);
-					return;
+				const [staticId, apiId] = await Promise.all([
+					fetchStaticBuildId(),
+					fetchApiBuildId(apiFetchAdapter),
+				]);
+
+				let outcome = resolveVersionCheckOutcome(localId, staticId, apiId, null);
+				if (outcome.type === 'register') {
+					const registeredId = await registerBuildId(outcome.buildId, apiFetchAdapter);
+					outcome = resolveVersionCheckOutcome(localId, staticId, apiId, registeredId);
 				}
 
-				if (remoteId === localId) {
+				if (outcome.type === 'register') {
+					await registerBuildId(outcome.buildId, apiFetchAdapter);
 					return;
 				}
-
-				const remoteNum = parseBuildId(remoteId);
-				if (remoteNum == null) {
-					await registerBuildId(localId);
+				if (outcome.type === 'reload') {
+					reloadForBuildId(outcome.remoteBuildId, localId);
 					return;
 				}
-
-				if (localNum > remoteNum) {
-					await registerBuildId(localId);
-					return;
-				}
-
-				if (localNum < remoteNum) {
-					reloadForBuildId(remoteId);
-				}
+				clearReloadAttempt(localId);
 			} finally {
 				checkingRef.current = false;
 			}
 		};
 
-		const onVisibility = (): void => {
+		const onWake = (): void => {
 			if (document.visibilityState === 'visible') {
 				void check();
 			}
@@ -137,13 +73,15 @@ export function useAppVersionCheck(): void {
 				return;
 			}
 			void check();
-		}, CHECK_INTERVAL_MS);
+		}, VERSION_CHECK_INTERVAL_MS);
 
-		document.addEventListener('visibilitychange', onVisibility);
+		document.addEventListener('visibilitychange', onWake);
+		window.addEventListener('focus', onWake);
 
 		return () => {
 			window.clearInterval(intervalId);
-			document.removeEventListener('visibilitychange', onVisibility);
+			document.removeEventListener('visibilitychange', onWake);
+			window.removeEventListener('focus', onWake);
 		};
 	}, []);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,20 @@
-import { defineConfig } from 'vitest/config';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Plugin } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url));
+
+function appVersionPlugin(buildId: string, outDir: string): Plugin {
+	return {
+		name: 'app-version',
+		closeBundle() {
+			const filePath = resolve(rootDir, outDir, 'version.json');
+			writeFileSync(filePath, JSON.stringify({ buildId }));
+		},
+	};
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode, ssrBuild }) => {
@@ -27,10 +42,11 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
 		};
 	} else {
 		const buildId = Date.now().toString();
+		const outDir = 'build';
 
 		// command === 'build'
 		return {
-			plugins: [react()],
+			plugins: [react(), appVersionPlugin(buildId, outDir)],
 			define: {
 				'import.meta.env.VITE_APP_BUILD_ID': JSON.stringify(buildId),
 			},


### PR DESCRIPTION
Вернули version.json в production-сборку и гибридную проверку: статический файл (сразу после деплоя) + /api/client-version. Исправлены ложный отказ reload из-за sessionStorage и игнор ответа register при недоступном GET. Повторная попытка — с cache-bust URL.