### PR TITLE
Версия: только бэкенд, удалён version.json и register от клиента

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev": "vite",
 		"start": "vite",
 		"build": "tsc && vite build",
+		"register-version": "bash scripts/register-client-version.sh",
 		"preview": "vite preview",
 		"test": "vitest",
 		"type-check": "tsc",

--- a/scripts/register-client-version.sh
+++ b/scripts/register-client-version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Registers the frontend buildId in the backend (single source of truth).
+#
+# Required env:
+#   VITE_APP_BUILD_ID  — same value used for `npm run build`
+#   DEPLOY_TOKEN       — must match backend app.deploy.token / DEPLOY_TOKEN
+#
+# Optional env:
+#   BACKEND_URL        — default https://friendly-bets-9fph3.ondigitalocean.app
+#
+# Typical CI order:
+#   export VITE_APP_BUILD_ID=$(date +%s%3N)
+#   npm run build
+#   ./scripts/register-client-version.sh
+#   # deploy build/ to static hosting
+
+BUILD_ID="${VITE_APP_BUILD_ID:-}"
+DEPLOY_TOKEN="${DEPLOY_TOKEN:-}"
+BACKEND_URL="${BACKEND_URL:-https://friendly-bets-9fph3.ondigitalocean.app}"
+
+if [[ -z "$BUILD_ID" ]]; then
+	echo "VITE_APP_BUILD_ID is required" >&2
+	exit 1
+fi
+
+if [[ -z "$DEPLOY_TOKEN" ]]; then
+	echo "DEPLOY_TOKEN is required" >&2
+	exit 1
+fi
+
+URL="${BACKEND_URL%/}/api/client-version"
+HTTP_CODE=$(curl -sS -o /tmp/client-version-response.json -w "%{http_code}" \
+	-X PUT "$URL" \
+	-H "Content-Type: application/json" \
+	-H "X-Deploy-Token: $DEPLOY_TOKEN" \
+	-d "{\"buildId\":\"$BUILD_ID\"}")
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+	echo "Failed to register client version (HTTP $HTTP_CODE):" >&2
+	cat /tmp/client-version-response.json >&2
+	exit 1
+fi
+
+echo "Registered client version buildId=$BUILD_ID"
+cat /tmp/client-version-response.json

--- a/src/shared/appVersionCheckLogic.test.ts
+++ b/src/shared/appVersionCheckLogic.test.ts
@@ -2,12 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	clearReloadAttempt,
 	parseBuildId,
-	pickNewestBuildId,
 	reloadForBuildId,
-	resolveVersionCheckOutcome,
-	shouldRegisterLocal,
 	shouldReload,
-	staticVersionUrl,
 } from './appVersionCheckLogic';
 
 describe('appVersionCheckLogic', () => {
@@ -22,31 +18,11 @@ describe('appVersionCheckLogic', () => {
 		expect(parseBuildId('not-a-version')).toBeNull();
 	});
 
-	it('pickNewestBuildId chooses the highest numeric build id', () => {
-		expect(pickNewestBuildId('100', '250', '200')).toBe('250');
-		expect(pickNewestBuildId(null, undefined, '120')).toBe('120');
-	});
-
 	it('shouldReload only when remote is newer', () => {
 		expect(shouldReload('100', '200')).toBe(true);
 		expect(shouldReload('200', '100')).toBe(false);
 		expect(shouldReload('200', '200')).toBe(false);
-	});
-
-	it('shouldRegisterLocal when local is newer or remote missing', () => {
-		expect(shouldRegisterLocal('300', '200')).toBe(true);
-		expect(shouldRegisterLocal('100', '200')).toBe(false);
-		expect(shouldRegisterLocal('100', null)).toBe(true);
-	});
-
-	it('resolveVersionCheckOutcome reloads old tab when static version is newer', () => {
-		const outcome = resolveVersionCheckOutcome('100', '300', '200', null);
-		expect(outcome).toEqual({ type: 'reload', remoteBuildId: '300' });
-	});
-
-	it('resolveVersionCheckOutcome registers when no remote version exists', () => {
-		const outcome = resolveVersionCheckOutcome('100', null, null, null);
-		expect(outcome).toEqual({ type: 'register', buildId: '100' });
+		expect(shouldReload('200', null)).toBe(false);
 	});
 
 	it('reloadForBuildId retries with cache-busting query on second attempt', () => {
@@ -70,12 +46,5 @@ describe('appVersionCheckLogic', () => {
 		sessionStorage.setItem('appReloadAttempt:100', '300');
 		clearReloadAttempt('100');
 		expect(sessionStorage.getItem('appReloadAttempt:100')).toBeNull();
-	});
-
-	it('staticVersionUrl always points to site root version.json', () => {
-		vi.stubGlobal('window', {
-			location: { origin: 'https://friendly-bets.net' },
-		});
-		expect(staticVersionUrl()).toBe('https://friendly-bets.net/version.json');
 	});
 });

--- a/src/shared/appVersionCheckLogic.ts
+++ b/src/shared/appVersionCheckLogic.ts
@@ -17,26 +17,7 @@ export function parseBuildId(value: string): number | null {
 	return null;
 }
 
-export function pickNewestBuildId(...ids: Array<string | null | undefined>): string | null {
-	let bestId: string | null = null;
-	let bestNum = -1;
-	for (const id of ids) {
-		if (!id) {
-			continue;
-		}
-		const num = parseBuildId(id);
-		if (num == null) {
-			continue;
-		}
-		if (num > bestNum) {
-			bestNum = num;
-			bestId = id;
-		}
-	}
-	return bestId;
-}
-
-export function shouldReload(localId: string, remoteId: string): boolean {
+export function shouldReload(localId: string, remoteId: string | null): boolean {
 	if (!remoteId || localId === remoteId) {
 		return false;
 	}
@@ -46,18 +27,6 @@ export function shouldReload(localId: string, remoteId: string): boolean {
 		return localId !== remoteId;
 	}
 	return localNum < remoteNum;
-}
-
-export function shouldRegisterLocal(localId: string, remoteId: string | null): boolean {
-	if (!remoteId) {
-		return true;
-	}
-	const localNum = parseBuildId(localId);
-	const remoteNum = parseBuildId(remoteId);
-	if (localNum == null || remoteNum == null) {
-		return localId !== remoteId;
-	}
-	return localNum > remoteNum;
 }
 
 function reloadAttemptKey(localBuildId: string): string {
@@ -88,13 +57,6 @@ export function reloadForBuildId(remoteBuildId: string, localBuildId: string): v
 	window.location.reload();
 }
 
-export function staticVersionUrl(): string {
-	if (typeof window !== 'undefined' && window.location?.origin) {
-		return `${window.location.origin}/version.json`;
-	}
-	return '/version.json';
-}
-
 export function clientVersionUrl(path: string): string {
 	if (import.meta.env.VITE_PRODUCT_SERVER === 'localhost') {
 		return path;
@@ -102,12 +64,11 @@ export function clientVersionUrl(path: string): string {
 	return `${import.meta.env.VITE_PRODUCT_SERVER}${path}`;
 }
 
-export async function fetchJsonBuildId(
-	url: string,
+export async function fetchApiBuildId(
 	fetchFn: typeof fetch = fetch
 ): Promise<string | null> {
 	try {
-		const response = await fetchFn(url, { cache: 'no-store' });
+		const response = await fetchFn(clientVersionUrl('/api/client-version'), { cache: 'no-store' });
 		if (!response.ok) {
 			return null;
 		}
@@ -116,61 +77,4 @@ export async function fetchJsonBuildId(
 	} catch {
 		return null;
 	}
-}
-
-export async function fetchStaticBuildId(fetchFn: typeof fetch = fetch): Promise<string | null> {
-	const url = `${staticVersionUrl()}?t=${Date.now()}`;
-	return fetchJsonBuildId(url, fetchFn);
-}
-
-export async function fetchApiBuildId(fetchFn: typeof fetch = fetch): Promise<string | null> {
-	return fetchJsonBuildId(clientVersionUrl('/api/client-version'), fetchFn);
-}
-
-export async function registerBuildId(
-	buildId: string,
-	fetchFn: typeof fetch = fetch
-): Promise<string | null> {
-	try {
-		const response = await fetchFn(clientVersionUrl('/api/client-version/register'), {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			cache: 'no-store',
-			body: JSON.stringify({ buildId }),
-		});
-		if (!response.ok) {
-			return null;
-		}
-		const data = (await response.json()) as VersionPayload;
-		return typeof data.buildId === 'string' && data.buildId ? data.buildId : null;
-	} catch {
-		return null;
-	}
-}
-
-export type VersionCheckOutcome =
-	| { type: 'noop' }
-	| { type: 'register'; buildId: string }
-	| { type: 'reload'; remoteBuildId: string };
-
-export function resolveVersionCheckOutcome(
-	localId: string,
-	staticId: string | null,
-	apiId: string | null,
-	registeredId: string | null
-): VersionCheckOutcome {
-	const remoteId = pickNewestBuildId(staticId, apiId, registeredId);
-	if (!remoteId) {
-		return { type: 'register', buildId: localId };
-	}
-	if (remoteId === localId) {
-		return { type: 'noop' };
-	}
-	if (shouldRegisterLocal(localId, remoteId)) {
-		return { type: 'register', buildId: localId };
-	}
-	if (shouldReload(localId, remoteId)) {
-		return { type: 'reload', remoteBuildId: remoteId };
-	}
-	return { type: 'noop' };
 }

--- a/src/shared/useAppVersionCheck.ts
+++ b/src/shared/useAppVersionCheck.ts
@@ -4,19 +4,15 @@ import {
 	VERSION_CHECK_INTERVAL_MS,
 	clearReloadAttempt,
 	fetchApiBuildId,
-	fetchStaticBuildId,
-	registerBuildId,
 	reloadForBuildId,
-	resolveVersionCheckOutcome,
+	shouldReload,
 } from './appVersionCheckLogic';
 
 const apiFetchAdapter: typeof fetch = (input, init) => apiFetch(input, init);
 
 /**
- * В production сверяет вшитый buildId с version.json (статика, сразу после деплоя)
- * и /api/client-version (бэкенд). Проверка сразу при возврате на вкладку, затем
- * каждые 5 минут пока вкладка видима. Более новый клиент регистрирует версию;
- * более старый — принудительный reload.
+ * В production сверяет вшитый buildId с /api/client-version (единственный источник правды).
+ * Проверка сразу при возврате на вкладку, затем каждые 5 минут пока вкладка видима.
  */
 export function useAppVersionCheck(): void {
 	const checkingRef = useRef(false);
@@ -37,23 +33,9 @@ export function useAppVersionCheck(): void {
 			}
 			checkingRef.current = true;
 			try {
-				const [staticId, apiId] = await Promise.all([
-					fetchStaticBuildId(),
-					fetchApiBuildId(apiFetchAdapter),
-				]);
-
-				let outcome = resolveVersionCheckOutcome(localId, staticId, apiId, null);
-				if (outcome.type === 'register') {
-					const registeredId = await registerBuildId(outcome.buildId, apiFetchAdapter);
-					outcome = resolveVersionCheckOutcome(localId, staticId, apiId, registeredId);
-				}
-
-				if (outcome.type === 'register') {
-					await registerBuildId(outcome.buildId, apiFetchAdapter);
-					return;
-				}
-				if (outcome.type === 'reload') {
-					reloadForBuildId(outcome.remoteBuildId, localId);
+				const remoteId = await fetchApiBuildId(apiFetchAdapter);
+				if (shouldReload(localId, remoteId)) {
+					reloadForBuildId(remoteId!, localId);
 					return;
 				}
 				clearReloadAttempt(localId);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,8 @@
-import { writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig, type Plugin } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
-const rootDir = fileURLToPath(new URL('.', import.meta.url));
-
-function appVersionPlugin(buildId: string, outDir: string): Plugin {
-	return {
-		name: 'app-version',
-		closeBundle() {
-			const filePath = resolve(rootDir, outDir, 'version.json');
-			writeFileSync(filePath, JSON.stringify({ buildId }));
-		},
-	};
-}
-
 // https://vitejs.dev/config/
-export default defineConfig(({ command, mode, ssrBuild }) => {
+export default defineConfig(({ mode }) => {
 	if (mode === 'development') {
 		return {
 			plugins: [react()],
@@ -40,35 +25,33 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
 				mockReset: true,
 			},
 		};
-	} else {
-		const buildId = Date.now().toString();
-		const outDir = 'build';
+	}
 
-		// command === 'build'
-		return {
-			plugins: [react(), appVersionPlugin(buildId, outDir)],
-			define: {
-				'import.meta.env.VITE_APP_BUILD_ID': JSON.stringify(buildId),
-			},
-			server: {
-				open: true,
-				proxy: {
-					'/api': {
-						target: '/',
-					},
+	const buildId = process.env.VITE_APP_BUILD_ID ?? Date.now().toString();
+
+	return {
+		plugins: [react()],
+		define: {
+			'import.meta.env.VITE_APP_BUILD_ID': JSON.stringify(buildId),
+		},
+		server: {
+			open: true,
+			proxy: {
+				'/api': {
+					target: '/',
 				},
 			},
-			build: {
-				outDir: 'build',
-				sourcemap: true,
-			},
-			base: './',
-			test: {
-				globals: true,
-				environment: 'jsdom',
-				setupFiles: 'src/setupTests',
-				mockReset: true,
-			},
-		};
-	}
+		},
+		build: {
+			outDir: 'build',
+			sourcemap: true,
+		},
+		base: './',
+		test: {
+			globals: true,
+			environment: 'jsdom',
+			setupFiles: 'src/setupTests',
+			mockReset: true,
+		},
+	};
 });


### PR DESCRIPTION
Проверка сверяет вшитый buildId с GET /api/client-version. CI регистрирует версию через scripts/register-client-version.sh после сборки.