### PR TITLE
register-version: retry пока бэкенд не поднимется после деплоя

### DIFF
--- a/scripts/register-client-version.sh
+++ b/scripts/register-client-version.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 #   DEPLOY_TOKEN       — must match backend app.deploy.token / DEPLOY_TOKEN
 #
 # API URL resolution (DO injects BACKEND_URL for static sites — do not use it):
-#   1. CLIENT_VERSION_BACKEND_URL — explicit override
-#   2. VITE_PRODUCT_SERVER        — same as runtime API origin (DO frontend env)
+#   1. CLIENT_VERSION_BACKEND_URL — recommended: direct DO backend URL
+#   2. VITE_PRODUCT_SERVER        — runtime API origin (friendly-bets.net/backend)
 #   3. https://friendly-bets-9fph3.ondigitalocean.app
 #
 # Typical DO build command:
@@ -17,6 +17,8 @@ set -euo pipefail
 
 BUILD_ID="${VITE_APP_BUILD_ID:-}"
 DEPLOY_TOKEN="${DEPLOY_TOKEN:-}"
+MAX_ATTEMPTS="${CLIENT_VERSION_REGISTER_ATTEMPTS:-12}"
+RETRY_DELAY_SECONDS="${CLIENT_VERSION_REGISTER_RETRY_SECONDS:-10}"
 
 resolve_api_origin() {
 	if [[ -n "${CLIENT_VERSION_BACKEND_URL:-}" ]]; then
@@ -45,17 +47,35 @@ fi
 URL="${API_ORIGIN}/api/client-version/deploy"
 echo "Registering client version at ${URL}"
 
-HTTP_CODE=$(curl -sS -o /tmp/client-version-response.json -w "%{http_code}" \
-	-X POST "$URL" \
-	-H "Content-Type: application/json" \
-	-H "X-Deploy-Token: $DEPLOY_TOKEN" \
-	-d "{\"buildId\":\"$BUILD_ID\"}")
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+	echo "Attempt ${attempt}/${MAX_ATTEMPTS}..."
 
-if [[ "$HTTP_CODE" != "200" ]]; then
-	echo "Failed to register client version (HTTP $HTTP_CODE):" >&2
-	cat /tmp/client-version-response.json >&2
-	exit 1
-fi
+	HTTP_CODE=$(curl -sS -o /tmp/client-version-response.json -w "%{http_code}" \
+		-X POST "$URL" \
+		-H "Content-Type: application/json" \
+		-H "X-Deploy-Token: $DEPLOY_TOKEN" \
+		-d "{\"buildId\":\"$BUILD_ID\"}" || echo "000")
 
-echo "Registered client version buildId=$BUILD_ID"
-cat /tmp/client-version-response.json
+	if [[ "$HTTP_CODE" == "200" ]]; then
+		echo "Registered client version buildId=$BUILD_ID"
+		cat /tmp/client-version-response.json
+		exit 0
+	fi
+
+	if [[ "$HTTP_CODE" == "403" ]]; then
+		echo "Failed to register client version (HTTP 403 — check DEPLOY_TOKEN):" >&2
+		cat /tmp/client-version-response.json >&2
+		exit 1
+	fi
+
+	echo "Register failed (HTTP ${HTTP_CODE}), waiting ${RETRY_DELAY_SECONDS}s..."
+	cat /tmp/client-version-response.json 2>/dev/null || true
+
+	if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+		sleep "$RETRY_DELAY_SECONDS"
+	fi
+done
+
+echo "Failed to register client version after ${MAX_ATTEMPTS} attempts (last HTTP ${HTTP_CODE}):" >&2
+cat /tmp/client-version-response.json >&2
+exit 1


### PR DESCRIPTION
DO деплоит фронт и бэкенд параллельно — /deploy отдаёт 404, пока новый образ бэкенда не live. До 12 попыток с паузой 10с; 403 не ретраим.